### PR TITLE
Change address-indexed records into arrays.

### DIFF
--- a/integration/Authentication.spec.ts
+++ b/integration/Authentication.spec.ts
@@ -56,15 +56,15 @@ async function authenticate(args: { address: string, sessionManager: SessionMana
         signedOn,
         attributes: [ session.id ],
     });
-    const signatures: Record<string, SessionSignature> = {
-        [ address ]: {
+    const signatures: SessionSignature[] = [ {
+            address,
             signature: typedSignature.signature,
             signedOn: toIsoString(signedOn),
             type: "POLKADOT",
         }
-    };
+    ];
     const signedSession = await sessionManager.signedSessionOrThrow(session, signatures);
 
     const tokens = await authenticator.createTokens(signedSession, DateTime.now());
-    return authenticator.ensureAuthenticatedUserOrThrow(tokens[address].value);
+    return authenticator.ensureAuthenticatedUserOrThrow(tokens[0].value);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/authenticator",
-  "version": "0.5.0-4",
+  "version": "0.5.0-5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/logion-network/logion-authenticator.git"

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -11,6 +11,7 @@ export interface Session {
 }
 
 export interface SessionSignature {
+    readonly address: string;
     readonly signature: string;
     readonly type: SignatureType;
     readonly signedOn: string;
@@ -18,7 +19,7 @@ export interface SessionSignature {
 
 export interface SignedSession {
     session: Session;
-    signatures: Record<string, SessionSignature>;
+    signatures: SessionSignature[];
 }
 
 export class SessionManager {
@@ -33,12 +34,11 @@ export class SessionManager {
         };
     }
 
-    async signedSessionOrThrow(session: Session, signatures: Record<string, SessionSignature>): Promise<SignedSession> {
-        for(const address of Object.keys(signatures)) {
-            const signature = signatures[address];
+    async signedSessionOrThrow(session: Session, signatures: SessionSignature[]): Promise<SignedSession> {
+        for(const signature of signatures) {
             const signatureService = this.config.signatureServices[signature.type];
             if (!await signatureService.verify({
-                address,
+                address: signature.address,
                 signature: signature.signature,
                 resource: "authentication",
                 operation: "login",

--- a/test/Authenticator.spec.ts
+++ b/test/Authenticator.spec.ts
@@ -17,15 +17,16 @@ describe('Authenticator', () => {
     it('generates a token for user', async () => {
         const authenticationService = new Authenticator(buildConfig());
         const signedSession = new Mock<SignedSession>();
-        signedSession.setup(instance => instance.signatures).returns({
-            [ USER_ADDRESS ]: {
+        signedSession.setup(instance => instance.signatures).returns([
+            {
+                address: USER_ADDRESS,
                 signature: "0x2c88db66ecf845896e1ba4c9fd02ebcb5ab5b84007b45edca6f0836007763c3fb1239824f07372dd41696e1f6558a700cd2c1a7b15fdb06e2041dd3b9878b988",
                 signedOn: DateTime.now().toISO() || "",
                 type: "POLKADOT"
-        }});
+        }]);
         const actual = await authenticationService.createTokens(signedSession.object(), DateTime.fromSeconds(1631217611));
-        expect(actual[USER_ADDRESS].value).toBe(USER_TOKEN);
-        expect(actual[USER_ADDRESS].expiredOn.toSeconds()).toBe(DateTime.fromSeconds(1631217611 + TTL).toSeconds());
+        expect(actual[0].value).toBe(USER_TOKEN);
+        expect(actual[0].expiredOn.toSeconds()).toBe(DateTime.fromSeconds(1631217611 + TTL).toSeconds());
     })
 
     it('authenticates user based on token', async () => {

--- a/test/Session.spec.ts
+++ b/test/Session.spec.ts
@@ -76,13 +76,13 @@ async function testSignedSessionOrThrow(signatureType: SignatureType, address: s
         signature: validSignature ? expectedSignature : "",
     };
     const { session, sessionManager } = buildSession(address, expected);
-    const signatures: Record<string, SessionSignature> = {
-        [address]: {
+    const signatures: SessionSignature[] = [ {
+            address,
             signature: expectedSignature,
             signedOn: DateTime.now().toISO() || "",
             type: signatureType,
         }
-    };
+    ];
 
     if(validSignature) {
         const signedSession = await sessionManager.signedSessionOrThrow(session, signatures);


### PR DESCRIPTION
* At authenticator level, there is no need to follow the pattern `<type>:<address>`: an array is used instead.
* In order to convey relevant info:
  * `SessionSignature` has thus a new attribute: `address`.
  * `Token` now extends `Address`

logion-network/logion-internal#851